### PR TITLE
Add unit and integration tests for Toolsmith modules

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
     targets: [
         .target(
             name: "SandboxRunner",
-            dependencies: [],
+            dependencies: ["ToolsmithSupport"],
             resources: [
                 .process("Profiles")
             ]
@@ -56,6 +56,22 @@ let package = Package(
         .executableTarget(
             name: "toolsmith-cli",
             dependencies: ["ToolsmithAPI", "ToolsmithSupport"]
+        ),
+        .testTarget(
+            name: "ToolsmithSupportTests",
+            dependencies: ["ToolsmithSupport"]
+        ),
+        .testTarget(
+            name: "ToolsmithTests",
+            dependencies: ["Toolsmith"]
+        ),
+        .testTarget(
+            name: "SandboxRunnerTests",
+            dependencies: ["SandboxRunner"]
+        ),
+        .testTarget(
+            name: "ToolsmithAPITests",
+            dependencies: ["ToolsmithAPI"]
         )
     ]
 )

--- a/Tests/SandboxRunnerTests/BwrapRunnerTests.swift
+++ b/Tests/SandboxRunnerTests/BwrapRunnerTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import SandboxRunner
+
+final class BwrapRunnerTests: XCTestCase {
+    func testPrepareCgroupAndAdd() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let runner = BwrapRunner(bwrap: URL(fileURLWithPath: "/bin/echo"), cgroupRoot: root)
+        let limits = CgroupLimits(memoryMax: "100M", cpuMax: "1000 1000", pidsMax: "10")
+        let path = try runner.prepareCgroup(limits: limits)
+        let mem = try String(contentsOf: path.appendingPathComponent("memory.max")).trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertEqual(mem, "100M")
+        let cpu = try String(contentsOf: path.appendingPathComponent("cpu.max")).trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertEqual(cpu, "1000 1000")
+        let pids = try String(contentsOf: path.appendingPathComponent("pids.max")).trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertEqual(pids, "10")
+        try runner.add(pid: 42, toCgroup: path)
+        let procs = try String(contentsOf: path.appendingPathComponent("cgroup.procs")).trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertEqual(procs, "42")
+    }
+}

--- a/Tests/SandboxRunnerTests/PathGuardTests.swift
+++ b/Tests/SandboxRunnerTests/PathGuardTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import SandboxRunner
+
+final class PathGuardTests: XCTestCase {
+    func testAllowsWorkDirectory() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        XCTAssertNoThrow(try guardWritePaths(arguments: ["file.txt", "-v"], workDirectory: tmp))
+    }
+
+    func testRejectsAbsolutePath() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        XCTAssertThrowsError(try guardWritePaths(arguments: ["/etc/passwd"], workDirectory: tmp))
+    }
+
+    func testRejectsParentReference() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        XCTAssertThrowsError(try guardWritePaths(arguments: ["../outside"], workDirectory: tmp))
+    }
+}

--- a/Tests/ToolsmithAPITests/APIClientTests.swift
+++ b/Tests/ToolsmithAPITests/APIClientTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+import Foundation
+import FoundationNetworking
+@testable import ToolsmithAPI
+
+final class APIClientTests: XCTestCase {
+    final class MockSession: HTTPSession {
+        var lastRequest: URLRequest?
+        var data: Data
+        init(data: Data) { self.data = data }
+        func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+            lastRequest = request
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (data, response)
+        }
+    }
+
+    func testSendEncodesBodyAndHeaders() async throws {
+        let responseData = try JSONEncoder().encode(ValidationResult(issues: [], ok: true))
+        let session = MockSession(data: responseData)
+        let client = APIClient(baseURL: URL(string: "https://example.com")!, bearerToken: "TOKEN", session: session)
+        let index = Index(documents: [])
+        let result: ValidationResult = try await client.send(pdfIndexValidate(body: index))
+        XCTAssertTrue(result.ok)
+        let req = session.lastRequest
+        XCTAssertEqual(req?.httpMethod, "POST")
+        XCTAssertEqual(req?.url?.path, "/pdf/index/validate")
+        XCTAssertEqual(req?.value(forHTTPHeaderField: "Authorization"), "Bearer TOKEN")
+        XCTAssertEqual(req?.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+}

--- a/Tests/ToolsmithSupportTests/ToolManifestTests.swift
+++ b/Tests/ToolsmithSupportTests/ToolManifestTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import ToolsmithSupport
+
+final class ToolManifestTests: XCTestCase {
+    func testLoadAndVerify() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let imageURL = tmp.appendingPathComponent("image.qcow2")
+        try Data("hello".utf8).write(to: imageURL)
+        let sha = try ToolManifest.sha256(of: imageURL)
+        let manifest = ToolManifest(image: .init(name: "img", tarball: "image.tar", sha256: sha, qcow2: "image.qcow2", qcow2_sha256: sha), tools: [:], operations: [])
+        let manifestURL = tmp.appendingPathComponent("tools.json")
+        try JSONEncoder().encode(manifest).write(to: manifestURL)
+        let loaded = try ToolManifest.load(from: manifestURL)
+        XCTAssertEqual(loaded.image.qcow2, "image.qcow2")
+        XCTAssertNoThrow(try loaded.verify(fileAt: imageURL))
+    }
+
+    func testVerifyChecksumMismatch() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let imageURL = tmp.appendingPathComponent("image.qcow2")
+        try Data("data".utf8).write(to: imageURL)
+        let manifest = ToolManifest(image: .init(name: "img", tarball: "image.tar", sha256: "bad", qcow2: "image.qcow2", qcow2_sha256: "bad"), tools: [:], operations: [])
+        do {
+            try manifest.verify(fileAt: imageURL)
+            XCTFail("Expected checksum mismatch")
+        } catch ToolManifest.ManifestError.checksumMismatch(let expected, let actual) {
+            XCTAssertEqual(expected, "bad")
+            XCTAssertNotEqual(expected, actual)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testVerifyImageNotListed() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let otherURL = tmp.appendingPathComponent("other.qcow2")
+        try Data().write(to: otherURL)
+        let manifest = ToolManifest(image: .init(name: "img", tarball: "image.tar", sha256: "", qcow2: "image.qcow2", qcow2_sha256: ""), tools: [:], operations: [])
+        XCTAssertThrowsError(try manifest.verify(fileAt: otherURL)) { error in
+            XCTAssertEqual(error as? ToolManifest.ManifestError, .imageNotListed)
+        }
+    }
+}

--- a/Tests/ToolsmithTests/ToolsmithTests.swift
+++ b/Tests/ToolsmithTests/ToolsmithTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import Foundation
+import FoundationNetworking
+@testable import Toolsmith
+
+final class ToolsmithTests: XCTestCase {
+    func captureOutput(_ work: () -> Void) -> String {
+        let pipe = Pipe()
+        let fd = dup(STDOUT_FILENO)
+        dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+        work()
+        fflush(nil)
+        dup2(fd, STDOUT_FILENO)
+        pipe.fileHandleForWriting.closeFile()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    func testRunLogsAndReturnsID() throws {
+        let toolsmith = Toolsmith()
+        let out = captureOutput {
+            _ = try? toolsmith.run(tool: "demo", metadata: ["k":"v"], operation: {})
+        }
+        let data = out.trimmingCharacters(in: .whitespacesAndNewlines).data(using: .utf8)!
+        let entry = try JSONDecoder().decode(LogEntry.self, from: data)
+        XCTAssertEqual(entry.tool, "demo")
+        XCTAssertEqual(entry.metadata["k"], "v")
+        XCTAssertGreaterThanOrEqual(entry.duration_ms, 0)
+    }
+
+    func testRunExportsSpanWhenEnvSet() throws {
+        class MockProtocol: URLProtocol {
+            nonisolated(unsafe) static var onRequest: (() -> Void)?
+            override class func canInit(with request: URLRequest) -> Bool { true }
+            override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+            override func startLoading() {
+                MockProtocol.onRequest?()
+                let response = HTTPURLResponse(url: self.request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                self.client?.urlProtocolDidFinishLoading(self)
+            }
+            override func stopLoading() {}
+        }
+        URLProtocol.registerClass(MockProtocol.self)
+        defer { URLProtocol.unregisterClass(MockProtocol.self) }
+        setenv("OTEL_EXPORT_URL", "http://example.com", 1)
+        let toolsmith = Toolsmith()
+        let exp = expectation(description: "span sent")
+        MockProtocol.onRequest = { exp.fulfill() }
+        let out = captureOutput {
+            _ = toolsmith.run(tool: "demo", operation: {})
+        }
+        wait(for: [exp], timeout: 1)
+        unsetenv("OTEL_EXPORT_URL")
+        let data = out.trimmingCharacters(in: .whitespacesAndNewlines).data(using: .utf8)!
+        let entry = try JSONDecoder().decode(LogEntry.self, from: data)
+        XCTAssertNotNil(entry.metadata["span_id"])
+    }
+}


### PR DESCRIPTION
## Summary
- add missing dependency and test targets in Package.swift
- cover ToolManifest loading and verification
- test logging and span export in Toolsmith
- verify sandbox path guards and cgroup helpers
- exercise APIClient request building

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68abf8d4e08c8333879db068b9cb666e