### PR TITLE
Add lifecycle telemetry logging and span attributes

### DIFF
--- a/Sources/Toolsmith/JSONLogger.swift
+++ b/Sources/Toolsmith/JSONLogger.swift
@@ -1,42 +1,183 @@
 import Foundation
+
 #if canImport(FoundationNetworking)
-import FoundationNetworking
+  import FoundationNetworking
 #endif
 
 public struct JSONLogger {
-    public init() {}
+  public init() {}
 
-    public func log(_ entry: LogEntry) {
-        if let data = try? JSONEncoder().encode(entry), let line = String(data: data, encoding: .utf8) {
-            print(line)
-        }
-    }
+  public func log(_ entry: LogEntry) {
+    emit(entry)
+  }
 
-    public func exportSpan(_ span: Span) {
-        guard let urlString = ProcessInfo.processInfo.environment["OTEL_EXPORT_URL"],
-              let url = URL(string: urlString) else { return }
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try? JSONEncoder().encode(span)
-        URLSession.shared.dataTask(with: request).resume()
+  public func logLifecycle(_ entry: LifecycleLogEntry) {
+    emit(entry)
+  }
+
+  public func lifecycleDownloadStarted(
+    requestID: String,
+    executionMode: String,
+    imageName: String,
+    cacheURL: URL,
+    source: URL? = nil
+  ) {
+    var metadata: [String: String] = [
+      "image_name": imageName,
+      "cache_path": cacheURL.path,
+    ]
+    if let source {
+      metadata["source"] = source.absoluteString
     }
+    logLifecycle(
+      LifecycleLogEntry(
+        request_id: requestID,
+        stage: "download_start",
+        timestamp: Date(),
+        execution_mode: executionMode,
+        metadata: metadata))
+  }
+
+  public func lifecycleDownloadFinished(
+    requestID: String,
+    executionMode: String,
+    imageName: String,
+    cacheURL: URL,
+    source: URL? = nil,
+    success: Bool,
+    errorDescription: String? = nil
+  ) {
+    var metadata: [String: String] = [
+      "image_name": imageName,
+      "cache_path": cacheURL.path,
+      "status": success ? "success" : "failed",
+    ]
+    if let source {
+      metadata["source"] = source.absoluteString
+    }
+    if let errorDescription {
+      metadata["error"] = errorDescription
+    }
+    logLifecycle(
+      LifecycleLogEntry(
+        request_id: requestID,
+        stage: "download_end",
+        timestamp: Date(),
+        execution_mode: executionMode,
+        metadata: metadata))
+  }
+
+  public func lifecycleChecksumVerified(
+    requestID: String,
+    executionMode: String,
+    imageName: String,
+    imageURL: URL,
+    digest: String
+  ) {
+    let metadata: [String: String] = [
+      "image_name": imageName,
+      "image_path": imageURL.path,
+      "digest": digest,
+    ]
+    logLifecycle(
+      LifecycleLogEntry(
+        request_id: requestID,
+        stage: "checksum_verified",
+        timestamp: Date(),
+        execution_mode: executionMode,
+        metadata: metadata))
+  }
+
+  public func lifecycleVMBooted(
+    requestID: String,
+    executionMode: String,
+    imageName: String,
+    imageURL: URL,
+    channelMetadata: [String: String]
+  ) {
+    var metadata: [String: String] = [
+      "image_name": imageName,
+      "image_path": imageURL.path,
+    ]
+    metadata.merge(channelMetadata) { _, new in new }
+    logLifecycle(
+      LifecycleLogEntry(
+        request_id: requestID,
+        stage: "vm_boot",
+        timestamp: Date(),
+        execution_mode: executionMode,
+        metadata: metadata))
+  }
+
+  public func lifecycleCommandDispatched(
+    requestID: String,
+    executionMode: String,
+    metadata: [String: String]
+  ) {
+    logLifecycle(
+      LifecycleLogEntry(
+        request_id: requestID,
+        stage: "command_dispatch",
+        timestamp: Date(),
+        execution_mode: executionMode,
+        metadata: metadata))
+  }
+
+  public func lifecycleShutdown(
+    requestID: String,
+    executionMode: String,
+    metadata: [String: String]
+  ) {
+    logLifecycle(
+      LifecycleLogEntry(
+        request_id: requestID,
+        stage: "shutdown",
+        timestamp: Date(),
+        execution_mode: executionMode,
+        metadata: metadata))
+  }
+
+  public func exportSpan(_ span: Span) {
+    guard let urlString = ProcessInfo.processInfo.environment["OTEL_EXPORT_URL"],
+      let url = URL(string: urlString)
+    else { return }
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try? JSONEncoder().encode(span)
+    URLSession.shared.dataTask(with: request).resume()
+  }
+
+  private func emit<T: Encodable>(_ value: T) {
+    if let data = try? JSONEncoder().encode(value), let line = String(data: data, encoding: .utf8) {
+      print(line)
+    }
+  }
 }
 
 public struct LogEntry: Codable {
-    public let request_id: String
-    public let tool: String
-    public let duration_ms: Int
-    public let metadata: [String: String]
+  public let request_id: String
+  public let tool: String
+  public let duration_ms: Int
+  public let metadata: [String: String]
+}
+
+public struct LifecycleLogEntry: Codable {
+  public let request_id: String
+  public let stage: String
+  public let timestamp: Date
+  public let execution_mode: String
+  public let metadata: [String: String]
 }
 
 public struct Span: Codable {
-    public let trace_id: String
-    public let span_id: String
-    public let parent_id: String?
-    public let name: String
-    public let start: Date
-    public let end: Date
+  public let trace_id: String
+  public let span_id: String
+  public let parent_id: String?
+  public let name: String
+  public let start: Date
+  public let end: Date
+  public let attributes: [String: String]?
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/Toolsmith/Toolsmith.swift
+++ b/Sources/Toolsmith/Toolsmith.swift
@@ -103,13 +103,19 @@ public final class Toolsmith {
   ) rethrows -> String {
     var meta = metadata
     let start = Date()
+    var executionModeValue: String?
     defer {
       let end = Date()
       let duration = Int(end.timeIntervalSince(start) * 1000)
+      if let executionModeValue {
+        meta["execution_mode"] = executionModeValue
+      }
       if ProcessInfo.processInfo.environment["OTEL_EXPORT_URL"] != nil {
         let spanID = UUID().uuidString
+        let attributes = executionModeValue.map { ["execution_mode": $0] }
         let span = Span(
-          trace_id: requestID, span_id: spanID, parent_id: nil, name: tool, start: start, end: end)
+          trace_id: requestID, span_id: spanID, parent_id: nil, name: tool, start: start,
+          end: end, attributes: attributes)
         logger.exportSpan(span)
         meta["span_id"] = spanID
       }
@@ -117,8 +123,11 @@ public final class Toolsmith {
       logger.log(entry)
     }
 
-    let (context, cleanup) = resolveExecutionContext(preferred: execution)
-    meta["execution_mode"] = context.mode.rawValue
+    let (context, cleanup, lifecycleMetadata) = resolveExecutionContext(
+      preferred: execution, requestID: requestID)
+    executionModeValue = context.mode.rawValue
+    logger.lifecycleCommandDispatched(
+      requestID: requestID, executionMode: context.mode.rawValue, metadata: lifecycleMetadata)
     defer { cleanup?() }
 
     try operation(context)
@@ -130,8 +139,8 @@ public final class Toolsmith {
     return try await hydrator.ensureImageAvailable()
   }
 
-  private func resolveExecutionContext(preferred execution: ExecutionMode)
-    -> (ExecutionContext, (() -> Void)?)
+  private func resolveExecutionContext(preferred execution: ExecutionMode, requestID: String)
+    -> (ExecutionContext, (() -> Void)?, [String: String])
   {
     let env = ProcessInfo.processInfo.environment["TOOLSMITH_EXECUTION"].flatMap {
       ExecutionMode(rawValue: $0)
@@ -155,27 +164,83 @@ public final class Toolsmith {
 
     switch resolvedMode {
     case .host:
-      return (ExecutionContext(mode: .host, backend: .host(.init())), nil)
+      let context = ExecutionContext(mode: .host, backend: .host(.init()))
+      return (context, nil, ["backend": "host"])
     case .vm:
       guard let imageHydrator else {
         let context = ExecutionContext(mode: .host, backend: .host(.init()))
-        return (context, nil)
+        return (context, nil, ["backend": "host", "reason": "missing_image"])
+      }
+      let cacheDirectory = imageHydrator.cacheDirectory()
+      let image = imageHydrator.image
+      let downloadRequired = !imageHydrator.cachedImageIsValid()
+      let sourceURL = try? imageHydrator.sourceURL()
+      if downloadRequired {
+        logger.lifecycleDownloadStarted(
+          requestID: requestID, executionMode: ExecutionMode.vm.rawValue, imageName: image.name,
+          cacheURL: cacheDirectory, source: sourceURL)
       }
       do {
         let imageURL = try waitForAsync { try await imageHydrator.ensureImageAvailable() }
+        if downloadRequired {
+          logger.lifecycleDownloadFinished(
+            requestID: requestID, executionMode: ExecutionMode.vm.rawValue, imageName: image.name,
+            cacheURL: cacheDirectory, source: sourceURL, success: true)
+        }
+        logger.lifecycleChecksumVerified(
+          requestID: requestID, executionMode: ExecutionMode.vm.rawValue, imageName: image.name,
+          imageURL: imageURL, digest: image.qcow2_sha256)
         let workspace = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
         let machine = VirtualMachine(imageURL: imageURL, manifest: manifest, workspace: workspace)
         let channel = try waitForAsync { try await machine.start() }
+        let channelMetadata: [String: String]
+        switch channel.endpoint.transport {
+        case .tcp(let host, let port):
+          channelMetadata = [
+            "transport": "tcp",
+            "host": host,
+            "port": String(port),
+          ]
+        case .unixDomainSocket(let path):
+          channelMetadata = [
+            "transport": "unix",
+            "path": path,
+          ]
+        }
+        logger.lifecycleVMBooted(
+          requestID: requestID, executionMode: ExecutionMode.vm.rawValue, imageName: image.name,
+          imageURL: imageURL, channelMetadata: channelMetadata)
+        var lifecycleMetadata = channelMetadata
+        lifecycleMetadata["backend"] = "vm"
+        lifecycleMetadata["image_name"] = image.name
+        lifecycleMetadata["image_path"] = imageURL.path
+        lifecycleMetadata["cache_path"] = cacheDirectory.path
         let context = ExecutionContext(mode: .vm, backend: .virtualMachine(channel))
-        let cleanup = {
+        let cleanup = { [logger = self.logger, requestID, lifecycleMetadata] in
+          logger.lifecycleShutdown(
+            requestID: requestID, executionMode: ExecutionMode.vm.rawValue,
+            metadata: lifecycleMetadata)
           _ = Task { await machine.shutdown() }
         }
-        return (context, cleanup)
+        return (context, cleanup, lifecycleMetadata)
       } catch {
-        return (ExecutionContext(mode: .host, backend: .host(.init())), nil)
+        if downloadRequired {
+          logger.lifecycleDownloadFinished(
+            requestID: requestID, executionMode: ExecutionMode.vm.rawValue, imageName: image.name,
+            cacheURL: cacheDirectory, source: sourceURL, success: false,
+            errorDescription: String(describing: error))
+        }
+        return (
+          ExecutionContext(mode: .host, backend: .host(.init())), nil,
+          [
+            "backend": "host",
+            "reason": "vm_unavailable",
+            "error": String(describing: error),
+          ]
+        )
       }
     case .automatic:
-      return (ExecutionContext(mode: .host, backend: .host(.init())), nil)
+      return (ExecutionContext(mode: .host, backend: .host(.init())), nil, ["backend": "host"])
     }
   }
 


### PR DESCRIPTION
## Summary
- extend the JSON logger with lifecycle entry support, span attributes, and VM lifecycle helpers
- expose cache metadata from the image hydrator and emit lifecycle logs during hydration, boot, and shutdown
- record execution mode in completion logs and command dispatch events for host and VM backends

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_b_68d2338165708333a94f167264ac613c